### PR TITLE
Make Data Structs public

### DIFF
--- a/internal/base/crud.config.go
+++ b/internal/base/crud.config.go
@@ -16,11 +16,13 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/vault/sdk/logical"
+
+	models "github.com/gateplane-io/vault-plugins/pkg/models/base"
 )
 
 /* ======================== CRUD Config*/
 
-func (b *BaseBackend) GetConfiguration(ctx context.Context, req *logical.Request) (*Config, error) {
+func (b *BaseBackend) GetConfiguration(ctx context.Context, req *logical.Request) (*models.Config, error) {
 
 	entry, err := req.Storage.Get(ctx, ConfigKey)
 	if err != nil {
@@ -30,7 +32,7 @@ func (b *BaseBackend) GetConfiguration(ctx context.Context, req *logical.Request
 		return nil, fmt.Errorf("Could not retrieve configuration from BaseBackend")
 	}
 
-	var config Config
+	var config models.Config
 	if err := json.Unmarshal(entry.Value, &config); err != nil {
 		b.Logger().Error("[-] Failed to unmarshal Config",
 			"error", err,
@@ -40,7 +42,7 @@ func (b *BaseBackend) GetConfiguration(ctx context.Context, req *logical.Request
 	return &config, nil
 }
 
-func (b *BaseBackend) StoreConfigurationToStorage(ctx context.Context, storage logical.Storage, config *Config) error {
+func (b *BaseBackend) StoreConfigurationToStorage(ctx context.Context, storage logical.Storage, config *models.Config) error {
 	configJSON, err := json.Marshal(*config)
 	if err != nil {
 		b.Logger().Error("[-] Could not marshal configuration to JSON",
@@ -65,6 +67,6 @@ func (b *BaseBackend) StoreConfigurationToStorage(ctx context.Context, storage l
 	return nil
 }
 
-func (b *BaseBackend) StoreConfiguration(ctx context.Context, req *logical.Request, config *Config) error {
+func (b *BaseBackend) StoreConfiguration(ctx context.Context, req *logical.Request, config *models.Config) error {
 	return b.StoreConfigurationToStorage(ctx, req.Storage, config)
 }

--- a/internal/base/crud.go
+++ b/internal/base/crud.go
@@ -13,6 +13,8 @@ package base
 import (
 	"fmt"
 	"time"
+
+	models "github.com/gateplane-io/vault-plugins/pkg/models/base"
 )
 
 /* Storage Keys */
@@ -26,36 +28,36 @@ func storageKeyForRequest(requestID string) string {
 	return fmt.Sprintf("%s/%s", RequestKey, requestID)
 }
 
-func requestHasExpired(accessRequest AccessRequest) bool {
+func requestHasExpired(accessRequest models.AccessRequest) bool {
 	return accessRequest.Expiration.Before(time.Now())
 }
 
-func requestIsDeletable(accessRequest AccessRequest, deleteAfter time.Duration) bool {
-	if accessRequest.Status != Expired {
+func requestIsDeletable(accessRequest models.AccessRequest, deleteAfter time.Duration) bool {
+	if accessRequest.Status != models.Expired {
 		return false
 	}
 	return accessRequest.Expiration.Before(time.Now().Add(-deleteAfter))
 }
 
-func approvalHasExpired(approval Approval) bool {
+func approvalHasExpired(approval models.Approval) bool {
 	return approval.Expiration.Before(time.Now())
 }
 
-func validApprovalsNum(accessRequest AccessRequest) int {
+func validApprovalsNum(accessRequest models.AccessRequest) int {
 	numOfvalidApprovals := 0
 	for _, approval := range accessRequest.Approvals {
 		// If someone changed their mind, the request can't be granted
 		// if approval.Status == ApprovalRetracted{
 		// 	return false
 		// }
-		if approval.Status == ApprovalActive {
+		if approval.Status == models.ApprovalActive {
 			numOfvalidApprovals++
 		}
 	}
 	return numOfvalidApprovals
 }
 
-func requestIsApproved(accessRequest AccessRequest, requiredApprovals int) bool {
+func requestIsApproved(accessRequest models.AccessRequest, requiredApprovals int) bool {
 	numOfvalidApprovals := validApprovalsNum(accessRequest)
 	return numOfvalidApprovals >= requiredApprovals
 }

--- a/internal/base/crud.grant_code.go
+++ b/internal/base/crud.grant_code.go
@@ -15,9 +15,11 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/vault/sdk/logical"
+
+	models "github.com/gateplane-io/vault-plugins/pkg/models/base"
 )
 
-func (b *BaseBackend) GetAccessRequestByGrantCode(ctx context.Context, req *logical.Request, grantCode string) (*AccessRequest, error) {
+func (b *BaseBackend) GetAccessRequestByGrantCode(ctx context.Context, req *logical.Request, grantCode string) (*models.AccessRequest, error) {
 
 	requestIDEntry, err := req.Storage.Get(ctx, fmt.Sprintf("%s/%s", GrantCodeKey, grantCode))
 	if err != nil {
@@ -71,7 +73,7 @@ func (b *BaseBackend) GetAccessRequestByGrantCode(ctx context.Context, req *logi
 		return nil, err
 	}
 
-	accessRequest.Status = AccessRequestStatus(Active)
+	accessRequest.Status = models.AccessRequestStatus(models.Active)
 	accessRequest.GrantCode = ""
 
 	err = b.storeRequest(ctx, req, accessRequest)
@@ -86,7 +88,7 @@ func (b *BaseBackend) GetAccessRequestByGrantCode(ctx context.Context, req *logi
 	return accessRequest, nil
 }
 
-func (b *BaseBackend) storeGrantCodeMap(ctx context.Context, req *logical.Request, accessRequest *AccessRequest) error {
+func (b *BaseBackend) storeGrantCodeMap(ctx context.Context, req *logical.Request, accessRequest *models.AccessRequest) error {
 
 	requestID := accessRequest.ID
 	requestIDEntry := []byte(requestID)

--- a/internal/base/endpoint.approve.go
+++ b/internal/base/endpoint.approve.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
+
+	models "github.com/gateplane-io/vault-plugins/pkg/models/base"
 )
 
 // Path for gatekeeper to grant access
@@ -67,7 +69,7 @@ func (b *BaseBackend) handleApprove(ctx context.Context, req *logical.Request, d
 		return logical.ErrorResponse("Corresponding request does not exist"), logical.ErrNotFound
 	}
 
-	if accessRequest.Status != Pending {
+	if accessRequest.Status != models.Pending {
 		return logical.ErrorResponse("Request cannot be approved as it is not in pending state"), logical.ErrPermissionDenied
 	}
 
@@ -76,7 +78,7 @@ func (b *BaseBackend) handleApprove(ctx context.Context, req *logical.Request, d
 		return logical.ErrorResponse("Approval by this entity already exists"), logical.ErrPermissionDenied
 	}
 
-	approval := NewApproval(config, entityID, requestID)
+	approval := models.NewApproval(config, entityID, requestID)
 	accessRequest.Approvals[entityID] = approval
 	approved := requestIsApproved(*accessRequest, config.RequiredApprovals)
 

--- a/internal/base/endpoint.request.go
+++ b/internal/base/endpoint.request.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
+
+	models "github.com/gateplane-io/vault-plugins/pkg/models/base"
 )
 
 // Path for user to request access
@@ -81,7 +83,7 @@ func (b *BaseBackend) handleRequestUpdate(ctx context.Context, req *logical.Requ
 		"ReasonNoWhitspaceLength", len(strings.TrimSpace(reason)),
 	)
 
-	accessRequest := NewAccessRequest(config, entityID, reason)
+	accessRequest := models.NewAccessRequest(config, entityID, reason)
 
 	err = b.storeRequest(ctx, req, &accessRequest)
 	if err != nil {

--- a/internal/base/plugin.go
+++ b/internal/base/plugin.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
+
+	models "github.com/gateplane-io/vault-plugins/pkg/models/base"
 )
 
 type BaseBackend struct {
@@ -28,7 +30,7 @@ func (b *BaseBackend) Initialize(ctx context.Context, req *logical.Initializatio
 	defer b.BaseMutex.Unlock()
 	b.Logger().Info("Initializing plugin configuration")
 
-	defaultConfig := NewDefaultConfig()
+	defaultConfig := models.NewDefaultConfig()
 	b.StoreConfigurationToStorage(ctx, req.Storage, &defaultConfig)
 
 	b.Logger().Info("Vault auth plugin initialized with default configuration",

--- a/internal/okta-group-gate/crud.config.go
+++ b/internal/okta-group-gate/crud.config.go
@@ -16,12 +16,14 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/vault/sdk/logical"
+
+	models "github.com/gateplane-io/vault-plugins/pkg/models/okta-group-gate"
 )
 
 /* ======================== CRUD Config*/
 const ConfigKey = "config"
 
-func (b *Backend) GetConfiguration(ctx context.Context, req *logical.Request) (*Config, error) {
+func (b *Backend) GetConfiguration(ctx context.Context, req *logical.Request) (*models.Config, error) {
 
 	entry, err := req.Storage.Get(ctx, ConfigKey)
 	if err != nil {
@@ -31,7 +33,7 @@ func (b *Backend) GetConfiguration(ctx context.Context, req *logical.Request) (*
 		return nil, fmt.Errorf("Could not retrieve configuration from PluginBackend")
 	}
 
-	var config Config
+	var config models.Config
 	if err := json.Unmarshal(entry.Value, &config); err != nil {
 		b.Logger().Error("[-] Failed to unmarshal Config",
 			"error", err,
@@ -41,7 +43,7 @@ func (b *Backend) GetConfiguration(ctx context.Context, req *logical.Request) (*
 	return &config, nil
 }
 
-func (b *Backend) StoreConfigurationToStorage(ctx context.Context, storage logical.Storage, config *Config) error {
+func (b *Backend) StoreConfigurationToStorage(ctx context.Context, storage logical.Storage, config *models.Config) error {
 	configJSON, err := json.Marshal(*config)
 	if err != nil {
 		b.Logger().Error("[-] Could not marshal configuration to JSON",
@@ -66,6 +68,6 @@ func (b *Backend) StoreConfigurationToStorage(ctx context.Context, storage logic
 	return nil
 }
 
-func (b *Backend) StoreConfiguration(ctx context.Context, req *logical.Request, config *Config) error {
+func (b *Backend) StoreConfiguration(ctx context.Context, req *logical.Request, config *models.Config) error {
 	return b.StoreConfigurationToStorage(ctx, req.Storage, config)
 }

--- a/internal/okta-group-gate/plugin.go
+++ b/internal/okta-group-gate/plugin.go
@@ -17,6 +17,8 @@ import (
 	"github.com/okta/okta-sdk-golang/v5/okta"
 
 	"github.com/gateplane-io/vault-plugins/internal/base"
+
+	models "github.com/gateplane-io/vault-plugins/pkg/models/okta-group-gate"
 )
 
 type Backend struct {
@@ -31,7 +33,7 @@ func (b *Backend) Initialize(ctx context.Context, req *logical.InitializationReq
 
 	// hadle defaults like this
 	// https://github.com/jfrog/vault-plugin-secrets-artifactory/blob/master/backend.go#L86
-	defaultConfig := NewDefaultConfig()
+	defaultConfig := models.NewDefaultConfig()
 	b.StoreConfigurationToStorage(ctx, req.Storage, &defaultConfig)
 
 	if b.oktaClient == nil {

--- a/internal/okta-group-gate/structs.okta-api.go
+++ b/internal/okta-group-gate/structs.okta-api.go
@@ -14,43 +14,7 @@ import (
 	"context"
 	"fmt"
 	"time"
-
-	"github.com/gateplane-io/vault-plugins/internal/base"
 )
-
-/*
-Embedding new fields to existing Struct
-and re-implementing Methods the CRUD
-*/
-
-type Config struct {
-	*base.Config
-	OktaGroupID string `json:"okta_group_id"`
-}
-
-func NewDefaultConfig() Config {
-	bConfig := base.NewDefaultConfig()
-	return Config{
-		Config:      &bConfig,
-		OktaGroupID: "",
-	}
-}
-
-func (c *Config) SetConfigurationKey(key string, value interface{}) error {
-	switch key {
-	// add the case of the new key
-	case "okta_group_id":
-		if v, ok := value.(string); ok {
-			c.OktaGroupID = v
-		} else {
-			return fmt.Errorf("invalid type for 'okta_group_id', expected string")
-		}
-
-	default:
-		return c.Config.SetConfigurationKey(key, value)
-	}
-	return nil
-}
 
 /*
 Configuration of Direct Okta API Access

--- a/internal/policy-gate/crud.config.go
+++ b/internal/policy-gate/crud.config.go
@@ -16,12 +16,14 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/vault/sdk/logical"
+
+	models "github.com/gateplane-io/vault-plugins/pkg/models/policy-gate"
 )
 
 /* ======================== CRUD Config*/
 const ConfigKey = "config"
 
-func (b *Backend) GetConfiguration(ctx context.Context, req *logical.Request) (*Config, error) {
+func (b *Backend) GetConfiguration(ctx context.Context, req *logical.Request) (*models.Config, error) {
 
 	entry, err := req.Storage.Get(ctx, ConfigKey)
 	if err != nil {
@@ -31,7 +33,7 @@ func (b *Backend) GetConfiguration(ctx context.Context, req *logical.Request) (*
 		return nil, fmt.Errorf("Could not retrieve configuration from PluginBackend")
 	}
 
-	var config Config
+	var config models.Config
 	if err := json.Unmarshal(entry.Value, &config); err != nil {
 		b.Logger().Error("[-] Failed to unmarshal Config",
 			"error", err,
@@ -41,7 +43,7 @@ func (b *Backend) GetConfiguration(ctx context.Context, req *logical.Request) (*
 	return &config, nil
 }
 
-func (b *Backend) StoreConfigurationToStorage(ctx context.Context, storage logical.Storage, config *Config) error {
+func (b *Backend) StoreConfigurationToStorage(ctx context.Context, storage logical.Storage, config *models.Config) error {
 	configJSON, err := json.Marshal(*config)
 	if err != nil {
 		b.Logger().Error("[-] Could not marshal configuration to JSON",
@@ -66,6 +68,6 @@ func (b *Backend) StoreConfigurationToStorage(ctx context.Context, storage logic
 	return nil
 }
 
-func (b *Backend) StoreConfiguration(ctx context.Context, req *logical.Request, config *Config) error {
+func (b *Backend) StoreConfiguration(ctx context.Context, req *logical.Request, config *models.Config) error {
 	return b.StoreConfigurationToStorage(ctx, req.Storage, config)
 }

--- a/internal/policy-gate/plugin.go
+++ b/internal/policy-gate/plugin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 
 	"github.com/gateplane-io/vault-plugins/internal/base"
+	models "github.com/gateplane-io/vault-plugins/pkg/models/policy-gate"
 )
 
 type Backend struct {
@@ -27,7 +28,7 @@ func (b *Backend) Initialize(ctx context.Context, req *logical.InitializationReq
 	defer b.BaseBackend.BaseMutex.Unlock()
 	b.Logger().Info("Initializing plugin configuration")
 
-	defaultConfig := NewDefaultConfig()
+	defaultConfig := models.NewDefaultConfig()
 	b.StoreConfigurationToStorage(ctx, req.Storage, &defaultConfig)
 
 	b.Logger().Info("Vault auth plugin initialized with default configuration",

--- a/pkg/models/base/structs.go
+++ b/pkg/models/base/structs.go
@@ -134,7 +134,7 @@ func NewAccessRequest(config *Config, entityID string, reason string) AccessRequ
 	}
 }
 
-func (accessRequest *AccessRequest) createGrantCode() error {
+func (accessRequest *AccessRequest) CreateGrantCode() error {
 	if accessRequest.GrantCode != "" {
 		return fmt.Errorf("GrantCode has already been created for AccessRequest %s", accessRequest.ID)
 	}

--- a/pkg/models/okta-group-gate/structs.go
+++ b/pkg/models/okta-group-gate/structs.go
@@ -8,12 +8,12 @@
 // Use, modification, and redistribution permitted under the terms of the license,
 // except for providing this software as a commercial service or product.
 
-package policy_gate
+package okta_group_gate
 
 import (
 	"fmt"
 
-	"github.com/gateplane-io/vault-plugins/internal/base"
+	"github.com/gateplane-io/vault-plugins/pkg/models/base"
 )
 
 /*
@@ -23,26 +23,27 @@ and re-implementing Methods the CRUD
 
 type Config struct {
 	*base.Config
-	Policies []string `json:"policies"`
+	OktaGroupID string `json:"okta_group_id"`
 }
 
 func NewDefaultConfig() Config {
 	bConfig := base.NewDefaultConfig()
 	return Config{
-		Config:   &bConfig,
-		Policies: []string{},
+		Config:      &bConfig,
+		OktaGroupID: "",
 	}
 }
 
 func (c *Config) SetConfigurationKey(key string, value interface{}) error {
 	switch key {
 	// add the case of the new key
-	case "policies":
-		if v, ok := value.([]string); ok {
-			c.Policies = v
+	case "okta_group_id":
+		if v, ok := value.(string); ok {
+			c.OktaGroupID = v
 		} else {
-			return fmt.Errorf("invalid type for policies, expected []string")
+			return fmt.Errorf("invalid type for 'okta_group_id', expected string")
 		}
+
 	default:
 		return c.Config.SetConfigurationKey(key, value)
 	}

--- a/pkg/models/policy-gate/structs.go
+++ b/pkg/models/policy-gate/structs.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Ioannis Torakis <john.torakis@gmail.com>
+// SPDX-License-Identifier: Elastic-2.0
+//
+// Licensed under the Elastic License 2.0.
+// You may obtain a copy of the license at:
+// https://www.elastic.co/licensing/elastic-license
+//
+// Use, modification, and redistribution permitted under the terms of the license,
+// except for providing this software as a commercial service or product.
+
+package policy_gate
+
+import (
+	"fmt"
+
+	"github.com/gateplane-io/vault-plugins/pkg/models/base"
+)
+
+/*
+Embedding new fields to existing Struct
+and re-implementing Methods the CRUD
+*/
+
+type Config struct {
+	*base.Config
+	Policies []string `json:"policies"`
+}
+
+func NewDefaultConfig() Config {
+	bConfig := base.NewDefaultConfig()
+	return Config{
+		Config:   &bConfig,
+		Policies: []string{},
+	}
+}
+
+func (c *Config) SetConfigurationKey(key string, value interface{}) error {
+	switch key {
+	// add the case of the new key
+	case "policies":
+		if v, ok := value.([]string); ok {
+			c.Policies = v
+		} else {
+			return fmt.Errorf("invalid type for policies, expected []string")
+		}
+	default:
+		return c.Config.SetConfigurationKey(key, value)
+	}
+	return nil
+}


### PR DESCRIPTION
As @dzervas initiated in this PR: https://github.com/gateplane-io/vault-plugins/pull/1,
the project can benefit from publishing its data structures.

This PR is complementary to https://github.com/gateplane-io/vault-plugins/pull/1, as it not only publishes `AccessRequest` and `Approval` models, but also the `Config` for each plugin.

This is work towards a CLI client.